### PR TITLE
Replace collection entry titles

### DIFF
--- a/resources/fieldsets/globals_seo_page_titles.yaml
+++ b/resources/fieldsets/globals_seo_page_titles.yaml
@@ -56,11 +56,12 @@ fields:
                 width: 33
                 listable: hidden
             -
-              handle: what_to_add
+              handle: manipulate_title
               field:
                 options:
-                  custom_text: 'Custom text'
-                  collection_title: 'The collection title'
+                  collection_title: 'Add collection title'
+                  custom_text: 'Add custom text'
+                  replace_title: 'Replace title'
                 multiple: false
                 max_items: 1
                 clearable: false
@@ -68,33 +69,33 @@ fields:
                 taggable: false
                 push_tags: false
                 cast_booleans: false
-                display: 'What to add'
+                display: 'Manipulate title'
                 type: select
                 icon: select
-                instructions: 'What to add.'
+                instructions: 'How to manipulate the title.'
                 width: 33
                 listable: hidden
             -
               handle: custom_text
               field:
                 input_type: text
-                antlers: false
+                antlers: true
                 display: Text
                 type: text
                 icon: text
-                instructions: 'The custom text.'
+                instructions: 'The custom text. You can use antlers tags in here.'
                 width: 33
                 listable: hidden
                 if:
-                  what_to_add: 'equals custom_text'
+                  what_to_add: 'isnt collection_title'
           mode: table
           add_row: 'Add collection default'
           reorderable: true
           type: grid
           icon: grid
           localizable: true
-          display: 'Change collection title'
-          instructions: 'Select collections where you want to add something to be part of the page title. For example: _Entry title - **Collection title** - Site title_.'
+          display: 'Manipulate collection title'
+          instructions: 'Select collections where you want to add something to be part of the page title. For example: _Entry title - **Custom text** - Site title_. You can also replace the whole title using the _Replace title_ option and optionally add Antlers tags.'
           listable: hidden
       -
         handle: section_environments_noindex

--- a/resources/fieldsets/seo.yaml
+++ b/resources/fieldsets/seo.yaml
@@ -15,7 +15,7 @@ fields:
       listable: hidden
       display: 'Page title'
       character_limit: 70
-      instructions: 'This entries title, defaults to title. Max 70 characters including the site name.'
+      instructions: 'This entries title, defaults to title and site name.'
   -
     handle: seo_description
     field: common.text_plain

--- a/resources/views/snippets/_seo.antlers.html
+++ b/resources/views/snippets/_seo.antlers.html
@@ -6,21 +6,22 @@
 <!-- statamic-peak-seo::snippets/_seo.antlers.html -->
 {{# Page title #}}
 <title>
+    {{ seperator = seo:title_separator ? seo:title_separator : " &#124; " }}
+    {{ site_name = seo:site_name ? seo:site_name : config:app:name }}
     {{ if seo_title }}
         {{ seo_title }}
-    {{ else }}
-        {{ yield:seo_title }}
-        {{ title }}
-        {{ seo:title_separator ? seo:title_separator : " &#124; " }}
+    {{ elseif seo:change_page_title | where('collection', {collection}) }}
         {{ seo:change_page_title | where('collection', {collection}) }}
-            {{ if what_to_add == 'collection_title' }}
-                {{ collection:title }}
-            {{ elseif what_to_add == 'custom_text' }}
+            {{ if manipulate_title == 'collection_title' }}
+                {{ title }} {{ seperator }} {{ collection:title }} {{ seperator }} {{ site_name }}
+            {{ elseif manipulate_title == 'custom_text' }}
+                {{ title }} {{ seperator }} {{ custom_text }} {{ seperator }} {{ site_name }}
+            {{ elseif manipulate_title == 'replace_title' }}
                 {{ custom_text }}
             {{ /if }}
-            {{ seo:title_separator ? seo:title_separator : " &#124; " }}
         {{ /seo:change_page_title }}
-        {{ seo:site_name ? seo:site_name : config:app:name }}
+    {{ else }}
+        {{ yield:seo_title }}{{ title }} {{ seperator }} {{ site_name }}
     {{ /if }}
 </title>
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -15,6 +15,10 @@ class ServiceProvider extends AddonServiceProvider
         'web' => __DIR__ . '/../routes/web.php',
     ];
 
+    protected $updateScripts = [
+        \Studio1902\PeakSEO\Updates\UpdateGlobalRenameWhatToAdd::class,
+    ];
+
     public function bootAddon()
     {
         $this->registerPublishableFieldsets();

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -16,7 +16,7 @@ class ServiceProvider extends AddonServiceProvider
     ];
 
     protected $updateScripts = [
-        \Studio1902\PeakSEO\Updates\UpdateGlobalRenameWhatToAdd::class,
+        \Studio1902\PeakSeo\Updates\UpdateGlobalRenameWhatToAdd::class,
     ];
 
     public function bootAddon()

--- a/src/Updates/UpdateGlobalRenameWhatToAdd.php
+++ b/src/Updates/UpdateGlobalRenameWhatToAdd.php
@@ -14,8 +14,10 @@ class UpdateGlobalRenameWhatToAdd extends UpdateScript
     public function update()
     {
         Site::all()->each(function ($site) {
-            $changePageTitles = GlobalSet::findByHandle('seo')->in($site->handle)->get('change_page_title');
-            // Rename `what_to_add` to `manipulate_title`.
+            $set = GlobalSet::findByHandle('seo')->in($site->handle);
+            $set->set('manipulate_title', $set->get('change_page_title'));
+            $set->remove('change_page_title');
+            $set->save();
         });
 
         $this->console()->info('Global "Change page title" configuration renamed `what_to_add` to `manipulate_title` succesfully.');

--- a/src/Updates/UpdateGlobalRenameWhatToAdd.php
+++ b/src/Updates/UpdateGlobalRenameWhatToAdd.php
@@ -15,6 +15,7 @@ class UpdateGlobalRenameWhatToAdd extends UpdateScript
     {
         Site::all()->each(function ($site) {
             $changePageTitles = GlobalSet::findByHandle('seo')->in($site->handle)->get('change_page_title');
+            // Rename `what_to_add` to `manipulate_title`.
         });
 
         $this->console()->info('Global "Change page title" configuration renamed `what_to_add` to `manipulate_title` succesfully.');

--- a/src/Updates/UpdateGlobalRenameWhatToAdd.php
+++ b/src/Updates/UpdateGlobalRenameWhatToAdd.php
@@ -1,0 +1,22 @@
+<?php
+
+use Statamic\Facades\GlobalSet;
+use Statamic\Facades\Site;
+use Statamic\UpdateScripts\UpdateScript;
+
+class UpdateGlobalRenameWhatToAdd extends UpdateScript
+{
+    public function shouldUpdate($newVersion, $oldVersion)
+    {
+        return $this->isUpdatingTo('2.0');
+    }
+
+    public function update()
+    {
+        Site::all()->each(function ($site) {
+            $changePageTitles = GlobalSet::findByHandle('seo')->in($site->handle)->get('change_page_title');
+        });
+
+        $this->console()->info('Global "Change page title" configuration renamed `what_to_add` to `manipulate_title` succesfully.');
+    }
+}

--- a/src/Updates/UpdateGlobalRenameWhatToAdd.php
+++ b/src/Updates/UpdateGlobalRenameWhatToAdd.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Studio1902\PeakSeo\Updates;
+
 use Statamic\Facades\GlobalSet;
 use Statamic\Facades\Site;
 use Statamic\UpdateScripts\UpdateScript;
@@ -15,9 +17,17 @@ class UpdateGlobalRenameWhatToAdd extends UpdateScript
     {
         Site::all()->each(function ($site) {
             $set = GlobalSet::findByHandle('seo')->in($site->handle);
-            $set->set('manipulate_title', $set->get('change_page_title'));
-            $set->remove('change_page_title');
-            $set->save();
+            $changePageTitle = $set->get('change_page_title');
+
+            if ($changePageTitle) {
+                foreach ($changePageTitle as $index => $values) {
+                    $changePageTitle[$index]['manipulate_title'] = $values['what_to_add'] ?? '';
+                    unset($changePageTitle[$index]['what_to_add']);
+                }
+
+                $set->set('change_page_title', $changePageTitle);
+                $set->save();
+            }
         });
 
         $this->console()->info('Global "Change page title" configuration renamed `what_to_add` to `manipulate_title` succesfully.');


### PR DESCRIPTION
Changes proposed in this pull request:
- Adds an option to replace collection entry title to the SEO global.
- Updates title antlers logic.
- Update script to migrate existing sites.
 
