### PR TITLE
Adds taxonomies and collection assigned taxonomies to sitemap

### DIFF
--- a/resources/fieldsets/globals_seo_sitemap.yaml
+++ b/resources/fieldsets/globals_seo_sitemap.yaml
@@ -10,3 +10,49 @@ fields:
       default: pages
       display: Collections
       width: 50
+  -
+    handle: sitemap_taxonomies
+    field:
+      mode: select
+      type: taxonomies
+      instructions: 'Select which taxonomies to include in the sitemap.xml.'
+      listable: hidden
+      display: Taxonomies
+      width: 50
+      instructions_position: above
+      visibility: visible
+      hide_display: false
+  -
+    handle: sitemap_collection_taxonomies
+    field:
+      fields:
+        -
+          handle: taxonomy
+          field:
+            max_items: 1
+            mode: select
+            type: taxonomies
+            listable: hidden
+            display: Taxonomy
+            width: 50
+            instructions_position: above
+            visibility: visible
+            hide_display: false
+            instructions: 'Select which taxonomy to use for specified collections.'
+        -
+          handle: collections
+          field:
+            mode: select
+            type: collections
+            listable: hidden
+            display: Collections
+            width: 50
+            instructions: "Select collections to assign the taxonomy's term urls."
+      mode: stacked
+      add_row: 'Add collection taxonomy'
+      reorderable: true
+      display: 'Collection Taxonomies'
+      type: grid
+      icon: grid
+      instructions: 'Select which collection term urls to include in the sitemap.xml. For example: _/blog/tags/retrowave_.'
+      listable: hidden

--- a/resources/views/sitemap/sitemap.antlers.xml
+++ b/resources/views/sitemap/sitemap.antlers.xml
@@ -22,4 +22,30 @@
             {{ /results }}
         {{ /collection }}
     {{ /seo:sitemap_collections }}
+    {{ seo:sitemap_taxonomies }}
+        {{ taxonomy from="{handle}" seo_noindex:isnt="true" as="results" }}
+            {{ results }}
+                <url>
+                    <loc>{{ permalink }}</loc>
+                    <lastmod>{{ updated_at format="Y-m-d"}}</lastmod>
+                    <changefreq>{{ sitemap_change_frequency ? sitemap_change_frequency : 'weekly' }}</changefreq>
+                    <priority>{{ sitemap_priority ? sitemap_priority : '0.5' }}</priority>
+                </url>
+            {{ /results }}
+        {{ /taxonomy }}
+    {{ /seo:sitemap_taxonomies }}
+    {{ seo:sitemap_collection_taxonomies }}
+        {{ collections }}
+            {{ taxonomy from="{taxonomy}" collection="{handle}" seo_noindex:isnt="true" as="results" }}
+                {{ results }}
+                    <url>
+                        <loc>{{ permalink }}</loc>
+                        <lastmod>{{ updated_at format="Y-m-d"}}</lastmod>
+                        <changefreq>{{ sitemap_change_frequency ? sitemap_change_frequency : 'weekly' }}</changefreq>
+                        <priority>{{ sitemap_priority ? sitemap_priority : '0.5' }}</priority>
+                    </url>
+                {{ /results }}
+            {{ /taxonomy }}
+        {{ /collections }}
+    {{ /seo:sitemap_collection_taxonomies }}
 </urlset>


### PR DESCRIPTION
Hey @robdekort 
I had a need for this and it seemed like a relatively simple PR. Let me know your thoughts.

 **Sitemap global blueprint:**
- Adds Taxonomies field to output taxonomy term urls
- Adds Collection Taxonomies field to output taxonomy term urls by collection

**Sitemap.xml template**
- Adds taxonomy tag to output taxonomy term urls by handle
- Adds taxonomy tag for each specified collection  to output collection term urls

<img width="950" alt="Screen Shot 2023-06-05 at 11 27 37 pm" src="https://github.com/studio1902/statamic-peak-seo/assets/414211/859abd2b-0b83-4b84-9520-b64f9a05618e">


