### PR TITLE
Support s3 drivers for social_images disk

### DIFF
--- a/src/Jobs/GenerateSocialImagesJob.php
+++ b/src/Jobs/GenerateSocialImagesJob.php
@@ -73,8 +73,12 @@ class GenerateSocialImagesJob implements ShouldQueue
         $image = Browsershot::url("{$absolute_url}/social-images/{$id}")
             ->windowSize(1200, 630)
             ->select('#og')
-            ->waitUntilNetworkIdle()
-            ->save($disk->path($file));
+            ->waitUntilNetworkIdle();
+        if (strtolower(config("filesystems.disks.{$container->disk}.driver") == 's3')) {
+            $disk->put($file, $image->screenshot());
+        } else {
+            $image->save($disk->path($file));
+        }
         $container->makeAsset($file)->save();
         $this->item->set('og_image', $file)->save();
 


### PR DESCRIPTION
Changes proposed in this pull request:

As discussed in https://github.com/studio1902/statamic-peak-seo/discussions/16

It adds a check for s3 driver when saving Browsershot in the GenerateSocialImagesJob. 
When using s3 disk, it puts the screenshot. When using local driver it just saves the image like before.

Tested with a fresh install of Peak, using both local disk and s3 disk. Generated the social images in both cases as expected. 