### PR TITLE
Adds support for s3 driver to store generated Twitteri mage

### DIFF
--- a/src/Jobs/GenerateSocialImagesJob.php
+++ b/src/Jobs/GenerateSocialImagesJob.php
@@ -87,8 +87,12 @@ class GenerateSocialImagesJob implements ShouldQueue
         $image = Browsershot::url("{$absolute_url}/social-images/{$id}")
             ->windowSize(1200, 600)
             ->select('#twitter')
-            ->waitUntilNetworkIdle()
-            ->save($disk->path($file));
+            ->waitUntilNetworkIdle();
+        if (strtolower(config("filesystems.disks.{$container->disk}.driver") == 's3')) {
+            $disk->put($file, $image->screenshot());
+        } else {
+            $image->save($disk->path($file));
+        }
         $container->makeAsset($file)->save();
         $this->item->set('twitter_image', $file)->save();
 


### PR DESCRIPTION
When adding support for the s3 driver for the social_images in the previous feature branch, it overlooked that it loops again to generate an image for Twitter as well.

This fixes that by applying the exact same fix. Tested with fresh install and multisite as well.

Might refactor the class a bit in the future to make it more modular and add support for optional Browsershot settings. First things first :)