### PR TITLE
Add ability to configure binary paths for social image generation

### DIFF
--- a/config/statamic-peak-seo.php
+++ b/config/statamic-peak-seo.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'social_image' => [
+        'node_binary' => env('SOCIAL_IMAGE_NODE_BINARY'),
+        'npm_binary' => env('SOCIAL_IMAGE_NPM_BINARY'),
+    ],
+];

--- a/src/Jobs/GenerateSocialImagesJob.php
+++ b/src/Jobs/GenerateSocialImagesJob.php
@@ -101,12 +101,12 @@ class GenerateSocialImagesJob implements ShouldQueue
 
         $browsershot = Browsershot::url("{$absolute_url}/social-images/{$id}");
 
-        if (config('statamic.peak-seo.node_binary')) {
-            $browsershot->setNodeBinary(config('statamic.peak-seo.node_binary'));
+        if ($nodeBinary = config('statamic-peak-seo.social_image.node_binary')) {
+            $browsershot->setNodeBinary($nodeBinary);
         }
 
-        if (config('statamic.peak-seo.npm_binary')) {
-            $browsershot->setNpmBinary(config('statamic.peak-seo.npm_binary'));
+        if ($npmBinary = config('statamic-peak-seo.social_image.npm_binary')) {
+            $browsershot->setNpmBinary($npmBinary);
         }
 
         return $browsershot;


### PR DESCRIPTION
Changes proposed in this pull request:
- Introduces a config file for the addon
- Ability to pass custom paths to the `npm` and `node` binary for Browsershot via `.env` file

Fixes:
- #20 