### PR TITLE
Adds config option for setting queue name

### DIFF
--- a/config/statamic-peak-seo.php
+++ b/config/statamic-peak-seo.php
@@ -4,5 +4,6 @@ return [
     'social_image' => [
         'node_binary' => env('SOCIAL_IMAGE_NODE_BINARY'),
         'npm_binary' => env('SOCIAL_IMAGE_NPM_BINARY'),
+        'queue_name' => env('SOCIAL_IMAGE_QUEUE', 'default')
     ],
 ];

--- a/src/Actions/GenerateSocialImages.php
+++ b/src/Actions/GenerateSocialImages.php
@@ -45,7 +45,8 @@ class GenerateSocialImages extends Action
     public function run($items, $values)
     {
         $items->each(function ($item, $key) {
-            GenerateSocialImagesJob::dispatch($item);
+            GenerateSocialImagesJob::dispatch($item)
+                ->onQueue(config('statamic-peak-seo.social_image.queue_name'));
         });
 
         $queue = config('queue.default');


### PR DESCRIPTION
As discussed, this adds a config option to specify the queue name for GernerateSocialImagesJob, with the 'default' queue as fallback. 

Running this in my production for testing and works beautifully with those jobs in my 'media' queue!