### PR TITLE
Fix to support multisite with absolute urls

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -3,6 +3,7 @@
 use Illuminate\Support\Facades\Route;
 use Statamic\Facades\GlobalSet;
 use Statamic\Facades\Site;
+use Statamic\Facades\URL;
 
 // The Sitemap Index route for listing sitemaps of all (multi)sites.
 Route::statamic('/sitemaps.xml', 'statamic-peak-seo::sitemap/sitemaps', [
@@ -24,9 +25,7 @@ Route::statamic('/{site_handle}/sitemap.xml', 'statamic-peak-seo::sitemap/sitema
 
 // The Social Image route to generate social images.
 if (GlobalSet::findByHandle('seo')?->inDefaultSite()?->get('use_social_image_generation')) {
-    Site::all()->each(function ($site) {
-        Route::statamic("{$site->url()}/social-images/{id}", 'statamic-peak-seo::social_images', [
-            'layout' => null,
-        ]);
-    });
+    Route::statamic(URL::makeRelative(Site::current()->url())."/social-images/{id}", 'statamic-peak-seo::social_images', [
+        'layout' => null,
+    ]);
 }


### PR DESCRIPTION
As discussed :) 

This updates the SocialImages route:

- No need to loop through the Sites and make multiple url's (thanks to @marcorieser), so updated it to one single route declaration.
- It now converts any absolute url's to relative urls, so that fixes the faulty route path when using this in multisite.

Tested with both a fresh install and in production with single site and multi site, relative urls and absolute urls in different combinations. It correctly generates the different language versions of the Social Images, as expected. 

P.S. Only url config that is not working is: `env('APP_URL').'/nl/'` but I can't think of a reason why you would use that, instead of a relative or absolute url. 