### PR TITLE
Feature/add body tracker fragment

### DIFF
--- a/resources/fieldsets/globals_seo_trackers_consent.yaml
+++ b/resources/fieldsets/globals_seo_trackers_consent.yaml
@@ -7,7 +7,7 @@ fields:
         none: None
         gtag: 'Google Analytics'
         gtm: 'Google Tag Manager'
-        scripts: Scripts
+        scripts: Custom scripts
       default: none
       type: button_group
       instructions: 'The type of tracking you want added on each page.'
@@ -83,6 +83,7 @@ fields:
                       options:
                         script_tag: 'Script tag'
                         inline_script: 'Inline script'
+                        body_content: 'Body content'
                       default: script_tag
                       display: Type
                       type: button_group
@@ -163,6 +164,30 @@ fields:
                         - required
                         - sometimes
                       instructions: 'The inline script tag contents (Javascript). Remove `<script>` and `</script>` tags.'
+                  -
+                    handle: body_content
+                    field:
+                      theme: material
+                      mode: javascript
+                      mode_selectable: false
+                      indent_type: tabs
+                      indent_size: 4
+                      key_map: default
+                      line_numbers: true
+                      line_wrapping: true
+                      display: 'Body content'
+                      type: code
+                      icon: code
+                      listable: hidden
+                      instructions_position: above
+                      visibility: visible
+                      always_save: false
+                      if:
+                        type: 'equals body_content'
+                      validate:
+                        - required
+                        - sometimes
+                      instructions: 'HTML that should be rendered after opening `<body>`.'
       display: Scripts
       type: replicator
       icon: replicator

--- a/resources/views/components/_cookie_banner.antlers.html
+++ b/resources/views/components/_cookie_banner.antlers.html
@@ -127,6 +127,15 @@
                         <span class="text-xs text-neutral/75">{{ explainer }}</span>
                     </span>
                 </label>
+
+                {{# Render this stack in all your layouts after opening the <body>. #}}
+                {{ script_fragments }}
+                    {{ if type == 'body_content' }}
+                        {{ push:seo_body }}
+                            {{ body_content }}
+                        {{ /push:seo_body }}
+                    {{ /if }}
+                {{ /script_fragments }}
             {{ /seo:scripts }}
         {{ /if }}
 

--- a/resources/views/snippets/_seo.antlers.html
+++ b/resources/views/snippets/_seo.antlers.html
@@ -211,15 +211,15 @@
         </script>
     {{ /if }}
 
-    {{# Yield this section in all your layouts after opening the <body> #}}
-    {{ section:seo_body }}
+    {{# Render this stack in all your layouts after opening the <body>. #}}
+    {{ push:seo_body }}
         {{ if seo:tracker_type == 'gtm' }}
             <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ seo:google_tag_manager }}" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         {{ /if }}
         {{ if seo:use_cookie_banner }}
             {{ partial:statamic-peak-seo::components/cookie_banner }}
         {{ /if }}
-    {{ /section:seo_body }}
+    {{ /push:seo_body }}
 
     {{ if seo:use_google_site_verification }}
         <meta name="google-site-verification" content="{{ seo:google_site_verification }}" />

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -17,6 +17,7 @@ class ServiceProvider extends AddonServiceProvider
 
     protected $updateScripts = [
         \Studio1902\PeakSeo\Updates\UpdateGlobalRenameWhatToAdd::class,
+        \Studio1902\PeakSeo\Updates\LayoutUpdateSectionToStack::class,
     ];
 
     public function bootAddon()

--- a/src/Updates/LayoutUpdateSectionToStack.php
+++ b/src/Updates/LayoutUpdateSectionToStack.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Studio1902\PeakSeo\Updates;
+
+use Illuminate\Support\Str;
+use Illuminate\Support\Facades\File;
+use Statamic\UpdateScripts\UpdateScript;
+
+class LayoutUpdateSectionToStack extends UpdateScript
+{
+    public function shouldUpdate($newVersion, $oldVersion)
+    {
+        return $this->isUpdatingTo('3.0');
+    }
+
+    public function update()
+    {
+        $layout = base_path("resources/views/layout.antlers.html");
+
+        if (File::exists($layout)) {
+            $contents = Str::of(File::get($layout))
+                ->replace('yield:seo_body', 'stack:seo_body');
+
+            File::put($layout, $contents);
+
+            $this->console()->info('Replaced `yield:seo_body` with `stack:seo_body` in `layout.antlers.html. Update this manually for any other layout files you may have.');
+        } else {
+            $this->console()->info('Replace `yield:seo_body` with `stack:seo_body` in all your layout files.');
+        }
+    }
+}


### PR DESCRIPTION
Add option to add after body content in the Custom Script option for Trackers. This update includes an update script to alter your default `layout.antlers.html`. 

Make sure you change `yield:seo_body` to `stack:seo_body` in any other layout files you might have.