### PR TITLE
Remove noscript gtm tracking

### DIFF
--- a/resources/views/snippets/_seo.antlers.html
+++ b/resources/views/snippets/_seo.antlers.html
@@ -213,9 +213,6 @@
 
     {{# Render this stack in all your layouts after opening the <body>. #}}
     {{ push:seo_body }}
-        {{ if seo:tracker_type == 'gtm' }}
-            <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ seo:google_tag_manager }}" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-        {{ /if }}
         {{ if seo:use_cookie_banner }}
             {{ partial:statamic-peak-seo::components/cookie_banner }}
         {{ /if }}


### PR DESCRIPTION
Since users with JavaScript disabled cannot consent to gtm tracking, it violates the GDPR to track them anyway.

Changes proposed in this pull request:
- Remove `noscript` gtm tracking
