### PR TITLE
Add cookie notice fields

### DIFF
--- a/resources/views/components/_cookie_banner.antlers.html
+++ b/resources/views/components/_cookie_banner.antlers.html
@@ -78,10 +78,10 @@
     <h2 class="text-2xl font-bold">{{ trans:strings.cookie_title }}</h2>
     <p class="text-sm font-bold text-neutral">
         {{ trans:strings.cookie_explanation }}
-        {{ if configuration:privacy_statement_type == 'entry' }}
-            <a class="px-1 -m-1 underline rounded hover:text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-primary" href="{{ configuration:privacy_statement_entry:url }}">{{ trans:strings.cookie_learn_more }}</a>
-        {{ elseif configuration:privacy_statement_type == 'pdf' }}
-            <a class="px-1 -m-1 underline rounded hover:text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-primary" href="{{ configuration:privacy_statement_asset }}" target="_blank">{{ trans:strings.cookie_learn_more }}</a>
+        {{ if configuration:cookie_notice_type == 'entry' }}
+            <a class="px-1 -m-1 underline rounded hover:text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-primary" href="{{ configuration:cookie_notice_entry:url }}">{{ trans:strings.cookie_learn_more }}</a>
+        {{ elseif configuration:cookie_notice_type == 'pdf' }}
+            <a class="px-1 -m-1 underline rounded hover:text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-primary" href="{{ configuration:cookie_notice_asset }}" target="_blank">{{ trans:strings.cookie_learn_more }}</a>
         {{ /if }}
     </p>
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -18,6 +18,7 @@ class ServiceProvider extends AddonServiceProvider
     protected $updateScripts = [
         \Studio1902\PeakSeo\Updates\UpdateGlobalRenameWhatToAdd::class,
         \Studio1902\PeakSeo\Updates\LayoutUpdateSectionToStack::class,
+        \Studio1902\PeakSeo\Updates\AddCookieNotice::class,
     ];
 
     public function bootAddon()

--- a/src/Updates/AddCookieNotice.php
+++ b/src/Updates/AddCookieNotice.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Studio1902\PeakSeo\Updates;
+
+use Statamic\Facades\GlobalSet;
+use Statamic\UpdateScripts\UpdateScript;
+
+class AddCookieNotice extends UpdateScript
+{
+    public function shouldUpdate($newVersion, $oldVersion)
+    {
+        // return $this->isUpdatingTo('7.0');
+        return true;
+    }
+
+    public function update()
+    {
+        $blueprint = GlobalSet::findByHandle('configuration')->blueprint();
+        $contents = $blueprint->contents();
+        $newSection = [
+            'display' => 'Cookie notice',
+            'instructions' => 'Configure an optional cookie notice.',
+            'fields' => [
+            0 => [
+                'handle' => 'cookie_notice_type',
+                'field' => [
+                'options' => [
+                    'none' => 'None',
+                    'entry' => 'Entry',
+                    'pdf' => 'PDF',
+                ],
+                'default' => 'none',
+                'type' => 'button_group',
+                'instructions' => 'This will be used in form consent and in the optional cookie banner.',
+                'instructions_position' => 'below',
+                'listable' => false,
+                'localizable' => true,
+                'display' => 'Cookie notice',
+                'width' => 50,
+                ],
+            ],
+            1 => [
+                'handle' => 'cookie_notice_asset',
+                'field' => 'common.image',
+                'config' => [
+                'container' => 'files',
+                'localizable' => true,
+                'listable' => 'hidden',
+                'display' => 'Cookie notice (PDF)',
+                'width' => 50,
+                'if' => [
+                    'cookie_notice_type' => 'equals pdf',
+                ],
+                'validate' => [
+                    0 => 'required_if:cookie_notice_type,pdf',
+                ],
+                ],
+            ],
+            2 => [
+                'handle' => 'cookie_notice_entry',
+                'field' => 'common.entry',
+                'config' => [
+                'localizable' => true,
+                'listable' => 'hidden',
+                'display' => 'Cookie notice (entry)',
+                'width' => 50,
+                'if' => [
+                    'cookie_notice_type' => 'equals entry',
+                ],
+                'validate' => [
+                    0 => 'required_if:cookie_notice_type,entry',
+                ],
+                ],
+            ],
+            ],
+        ];
+        $contents['tabs']['general']['sections'][] = $newSection;
+        $blueprint->setContents($contents);
+        $blueprint->save();
+
+        $this->console()->info('Global Configuration Blueprint succesfully expanded with Cookie Notice fields.');
+    }
+}


### PR DESCRIPTION
Add cookie notice fields to globals using an update script, and use those fields - if available - in the cookie banner.