### PR TITLE
SEO Routes per Site in Multisite

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -5,21 +5,28 @@ use Statamic\Facades\GlobalSet;
 use Statamic\Facades\Site;
 use Statamic\Facades\URL;
 
+$useSocialImageGeneration = (bool)GlobalSet::findByHandle('seo')?->inDefaultSite()?->get('use_social_image_generation');
+
 // The Sitemap Index route for listing sitemaps of all (multi)sites.
 Route::statamic('/sitemaps.xml', 'statamic-peak-seo::sitemap/sitemaps', [
     'layout' => null,
     'content_type' => 'application/xml'
 ]);
 
-// The Default Site Sitemap route.
-Route::statamic(URL::makeRelative(Site::current()->url()).'/sitemap.xml', 'statamic-peak-seo::sitemap/sitemap', [
-    'layout' => null,
-    'content_type' => 'application/xml'
-]);
+// Register routes for each site.
+Site::all()->each(function (\Statamic\Sites\Site $site) use ($useSocialImageGeneration) {
+    $relativeSiteUrl = URL::makeRelative($site->url());
 
-// The Social Image route to generate social images.
-if (GlobalSet::findByHandle('seo')?->inDefaultSite()?->get('use_social_image_generation')) {
-    Route::statamic(URL::makeRelative(Site::current()->url())."/social-images/{id}", 'statamic-peak-seo::social_images', [
+    // The Sitemap route.
+    Route::statamic(URL::tidy($relativeSiteUrl . '/sitemap.xml'), 'statamic-peak-seo::sitemap/sitemap', [
         'layout' => null,
+        'content_type' => 'application/xml'
     ]);
-}
+
+    // The Social Image route to generate social images.
+    if ($useSocialImageGeneration) {
+        Route::statamic(URL::tidy($relativeSiteUrl . '/social-images/{id}'), 'statamic-peak-seo::social_images', [
+            'layout' => null,
+        ]);
+    }
+});


### PR DESCRIPTION
Fixes #33 .

Changes proposed in this pull request:
- Register SEO routes explicitly per site in a multisite setup which allows caching the routes
