### PR TITLE
Adding og:url to seo partial

### DIFF
--- a/resources/views/snippets/_seo.antlers.html
+++ b/resources/views/snippets/_seo.antlers.html
@@ -124,6 +124,7 @@
 <meta property="og:site_name" content="{{ seo:site_name ? seo:site_name : config:app:name }}">
 <meta property="og:type" content="website">
 <meta property="og:locale" content="{{ site:locale }}">
+<meta property="og:url" content="{{ permalink }}">
 {{ if og_title }}
     <meta property="og:title" content="{{ og_title | strip_tags | entities | trim }}">
 {{ else }}


### PR DESCRIPTION
When running a newly created website through Ahrefs I found out the opengraph implementation is missing the og:url tag. 

Apparently there are 4 required og-tags:
![Scherm­afbeelding 2023-11-22 om 09 39 21](https://github.com/studio1902/statamic-peak-seo/assets/7419859/11166278-b6c0-4f2b-80e0-a53a5e79bada)

