### PR TITLE
Added type for Script tag

### DIFF
--- a/resources/views/snippets/_seo.antlers.html
+++ b/resources/views/snippets/_seo.antlers.html
@@ -158,7 +158,7 @@
         {{ seo:scripts }}
             {{ script_fragments }}
                 {{ if type == 'script_tag' }}
-                    <script {{ async ?= 'async' }} {{ defer ?= 'defer' }} src="{{ source }}"></script>
+                    <script type="text/javascript" {{ async ?= 'async' }} {{ defer ?= 'defer' }} src="{{ source }}"></script>
                 {{ else }}
                     <script>{{ inline_script }}</script>
                 {{ /if }}


### PR DESCRIPTION
Today, when adding a custom script tag, I was surprised that the type is not specified when selecting Script tag. 

Here's a quick edit :)

**Changes proposed in this pull request:**
- Added type for Script tag
  - If the user selects custom scripts on the Trackers tab and selects the Script tag as the script fragment, this tag will now also have the type - `type="text/javascript"`
