### PR TITLE
Make all fields localizable by default

### DIFF
--- a/resources/fieldsets/globals_seo_page_descriptions.yaml
+++ b/resources/fieldsets/globals_seo_page_descriptions.yaml
@@ -73,3 +73,4 @@ fields:
       icon: grid
       instructions: 'Set fallback meta descriptions for each collection.'
       listable: hidden
+      localizable: true

--- a/resources/fieldsets/globals_seo_page_environments.yaml
+++ b/resources/fieldsets/globals_seo_page_environments.yaml
@@ -8,6 +8,7 @@ fields:
       listable: false
       display: Local
       width: 33
+      localizable: true
   -
     handle: noindex_staging
     field:
@@ -16,6 +17,7 @@ fields:
       listable: false
       display: Staging
       width: 33
+      localizable: true
   -
     handle: noindex_production
     field:
@@ -24,3 +26,4 @@ fields:
       listable: false
       display: Production
       width: 33
+      localizable: true

--- a/resources/fieldsets/globals_seo_page_hreflang.yaml
+++ b/resources/fieldsets/globals_seo_page_hreflang.yaml
@@ -9,3 +9,4 @@ fields:
       listable: hidden
       instructions_position: above
       width: 50
+      localizable: true

--- a/resources/fieldsets/globals_seo_sitemap.yaml
+++ b/resources/fieldsets/globals_seo_sitemap.yaml
@@ -58,7 +58,6 @@ fields:
             visibility: visible
             hide_display: false
             instructions: 'Select which taxonomy to use for specified collections.'
-            localizable: true
         -
           handle: collections
           field:
@@ -68,7 +67,6 @@ fields:
             display: Collections
             width: 50
             instructions: "Select collections to assign the taxonomy's term urls."
-            localizable: true
       mode: stacked
       add_row: 'Add collection taxonomy'
       reorderable: true

--- a/resources/fieldsets/globals_seo_sitemap.yaml
+++ b/resources/fieldsets/globals_seo_sitemap.yaml
@@ -10,6 +10,7 @@ fields:
       instructions: 'Enable the Peak Sitemap.'
       instructions_position: below
       listable: hidden
+      localizable: true
   -
     handle: sitemap_collections
     field:
@@ -21,6 +22,7 @@ fields:
       display: Collections
       width: 50
       always_save: true
+      localizable: true
       if:
         use_sitemap: 'equals true'
   -
@@ -36,6 +38,7 @@ fields:
       visibility: visible
       hide_display: false
       always_save: true
+      localizable: true
       if:
         use_sitemap: 'equals true'
   -
@@ -55,6 +58,7 @@ fields:
             visibility: visible
             hide_display: false
             instructions: 'Select which taxonomy to use for specified collections.'
+            localizable: true
         -
           handle: collections
           field:
@@ -64,6 +68,7 @@ fields:
             display: Collections
             width: 50
             instructions: "Select collections to assign the taxonomy's term urls."
+            localizable: true
       mode: stacked
       add_row: 'Add collection taxonomy'
       reorderable: true
@@ -73,5 +78,6 @@ fields:
       instructions: 'Select which collection term urls to include in the sitemap.xml. For example: _/blog/tags/retrowave_.'
       listable: hidden
       always_save: true
+      localizable: true
       if:
         use_sitemap: 'equals true'

--- a/resources/fieldsets/globals_seo_social_generate_social_images.yaml
+++ b/resources/fieldsets/globals_seo_social_generate_social_images.yaml
@@ -10,6 +10,7 @@ fields:
       instructions_position: below
       listable: hidden
       width: 50
+      localizable: true
   -
     handle: social_images_collections
     field:
@@ -21,6 +22,7 @@ fields:
       instructions_position: below
       listable: hidden
       width: 50
+      localizable: true
       if:
         use_social_image_generation: 'equals true'
   - 
@@ -33,5 +35,6 @@ fields:
       instructions_position: below
       listable: hidden
       width: 100
+      localizable: true
       if:
         use_social_image_generation: 'equals true'

--- a/resources/fieldsets/globals_seo_trackers_analytics.yaml
+++ b/resources/fieldsets/globals_seo_trackers_analytics.yaml
@@ -7,6 +7,7 @@ fields:
       instructions: 'Add Fathom tracking code to your head.'
       listable: false
       display: Fathom
+      localizable: true
   -
     handle: fathom
     field:
@@ -16,6 +17,7 @@ fields:
       type: text
       listable: hidden
       width: 50
+      localizable: true
       validate:
         - 'required_if:use_fathom,true'
       if:
@@ -27,6 +29,7 @@ fields:
       instructions: 'Add the Matomo self hosted tag manager to your head.'
       listable: false
       display: Matomo
+      localizable: true
   -
     handle: matomo_script_url
     field:
@@ -36,6 +39,7 @@ fields:
       type: text
       listable: hidden
       width: 50
+      localizable: true
       validate:
         - 'required_if:use_matomo,true'
       if:
@@ -47,6 +51,7 @@ fields:
       instructions: 'Add Plausible tracking code to your head.'
       listable: false
       display: Plausible
+      localizable: true
   -
     handle: plausible_use_custom_script
     field:
@@ -56,6 +61,7 @@ fields:
       display: 'Custom script'
       instructions_position: above
       default: false
+      localizable: true
       if:
         use_plausible: 'equals true'
   -
@@ -67,6 +73,7 @@ fields:
       type: text
       listable: hidden
       width: 50
+      localizable: true
       validate:
         - 'required_if:use_plausible,true'
       if:
@@ -80,6 +87,7 @@ fields:
       type: text
       listable: hidden
       width: 50
+      localizable: true
       validate:
         - 'required_if:plausible_use_custom_domain,true'
       if:
@@ -94,6 +102,7 @@ fields:
       instructions: 'Add Cloudflare tracking code to your head.'
       listable: false
       display: 'Cloudflare Web Analytics'
+      localizable: true
   -
     handle: cloudflare_web_analytics
     field:
@@ -102,6 +111,7 @@ fields:
       width: 50
       type: text
       listable: hidden
+      localizable: true
       validate:
         - 'required_if:use_cloudflare_web_analytics,true'
       if:

--- a/resources/fieldsets/globals_seo_trackers_consent.yaml
+++ b/resources/fieldsets/globals_seo_trackers_consent.yaml
@@ -16,6 +16,7 @@ fields:
       instructions_position: above
       visibility: visible
       always_save: false
+      localizable: true
   -
     handle: scripts
     field:
@@ -253,6 +254,7 @@ fields:
       input_type: text
       type: text
       listable: hidden
+      localizable: true
       validate:
         - 'required_if:tracker_type,gtag'
       if:
@@ -267,6 +269,7 @@ fields:
       display: "Anonymize IP's"
       instructions: "Even if you anonymize IP's you need consent according to the GDPR."
       instructions_position: below
+      localizable: true
       if:
         tracker_type: 'equals gtag'
   -
@@ -278,6 +281,7 @@ fields:
       width: 50
       display: 'Tracking ID'
       instructions_position: below
+      localizable: true
       validate:
         - 'required_if:tracker_type,gtm'
       if:
@@ -290,6 +294,7 @@ fields:
       instructions_position: below
       listable: false
       display: 'Consent banner'
+      localizable: true
   -
     handle: embeds
     field:
@@ -302,6 +307,7 @@ fields:
       visibility: visible
       always_save: false
       width: 50
+      localizable: true
       if:
         use_consent_banner: 'equals true'
   -
@@ -316,6 +322,7 @@ fields:
       visibility: visible
       replicator_preview: true
       hide_display: false
+      localizable: true
       if:
         embeds: 'equals true'
   -
@@ -351,6 +358,7 @@ fields:
       width: 66
       listable: hidden
       use_consent_banner: 'equals true'
+      localizable: true
   -
     handle: display_style
     field:

--- a/resources/fieldsets/globals_seo_trackers_consent.yaml
+++ b/resources/fieldsets/globals_seo_trackers_consent.yaml
@@ -336,6 +336,7 @@ fields:
       instructions_position: below
       visibility: visible
       always_save: false
+      localizable: true
       if:
         use_consent_banner: 'equals true'
         embeds: 'equals true'
@@ -384,6 +385,7 @@ fields:
       visibility: visible
       replicator_preview: false
       hide_display: false
+      localizable: true
       if:
         tracker_type: 'equals gtm'
         use_consent_banner: 'equals true'
@@ -398,6 +400,7 @@ fields:
       visibility: visible
       replicator_preview: true
       hide_display: false
+      localizable: true
       if:
         tracker_type: 'equals gtm'
         use_consent_banner: 'equals true'
@@ -412,6 +415,7 @@ fields:
       visibility: visible
       replicator_preview: true
       hide_display: false
+      localizable: true
       if:
         tracker_type: 'equals gtm'
         use_consent_banner: 'equals true'
@@ -426,6 +430,7 @@ fields:
       visibility: visible
       replicator_preview: true
       hide_display: false
+      localizable: true
       if:
         tracker_type: 'equals gtm'
         use_consent_banner: 'equals true'
@@ -440,6 +445,7 @@ fields:
       visibility: visible
       replicator_preview: true
       hide_display: false
+      localizable: true
       if:
         tracker_type: 'equals gtm'
         use_consent_banner: 'equals true'

--- a/resources/fieldsets/globals_seo_trackers_environments.yaml
+++ b/resources/fieldsets/globals_seo_trackers_environments.yaml
@@ -7,6 +7,7 @@ fields:
       listable: false
       display: Local
       width: 33
+      localizable: true
   -
     handle: trackers_staging
     field:
@@ -14,6 +15,7 @@ fields:
       listable: false
       display: Staging
       width: 33
+      localizable: true
   -
     handle: trackers_production
     field:
@@ -21,3 +23,4 @@ fields:
       listable: false
       display: Production
       width: 33
+      localizable: true

--- a/resources/fieldsets/globals_seo_trackers_site_verifications.yaml
+++ b/resources/fieldsets/globals_seo_trackers_site_verifications.yaml
@@ -7,6 +7,7 @@ fields:
       instructions: 'Add a google-site-verification meta tag to your head.'
       listable: false
       display: 'Google site verification'
+      localizable: true
   -
     handle: google_site_verification
     field:
@@ -15,6 +16,7 @@ fields:
       listable: hidden
       width: 66
       display: 'Verification key'
+      localizable: true
       validate:
         - 'required_if:use_google_site_verification,true'
       if:

--- a/resources/fieldsets/seo_advanced.yaml
+++ b/resources/fieldsets/seo_advanced.yaml
@@ -9,6 +9,7 @@ fields:
       listable: hidden
       width: 50
       display: No-index
+      localizable: true
   -
     handle: seo_nofollow
     field:
@@ -18,6 +19,7 @@ fields:
       listable: hidden
       width: 50
       display: No-follow
+      localizable: true
   -
     handle: seo_canonical_type
     field:
@@ -31,6 +33,7 @@ fields:
       icon: button_group
       instructions: 'Where should the canonical URL for this entry point to.'
       listable: hidden
+      localizable: true
   -
     handle: seo_canonical_current
     field: common.entry
@@ -52,6 +55,7 @@ fields:
       type: text
       icon: text
       listable: hidden
+      localizable: true
       validate:
         - 'required_if:seo_canonical_type,external'
       if:

--- a/resources/fieldsets/seo_basic.yaml
+++ b/resources/fieldsets/seo_basic.yaml
@@ -18,3 +18,4 @@ fields:
       display: 'Meta description'
       character_limit: '160'
       instructions: "This entry's meta description. Max 160 characters."
+      localizable: true

--- a/resources/fieldsets/seo_jsonld.yaml
+++ b/resources/fieldsets/seo_jsonld.yaml
@@ -8,3 +8,4 @@ fields:
       display: 'JSON-ld schema'
       instructions: 'Custom JSON-ld objects. Will be wrapped in the appropriate script tag.'
       width: 100
+      localizable: true

--- a/resources/fieldsets/seo_open_graph.yaml
+++ b/resources/fieldsets/seo_open_graph.yaml
@@ -17,6 +17,7 @@ fields:
       display: 'Social description'
       instructions: "This entry's OG description, defaults to meta description."
       width: 100
+      localizable: true
   -
     handle: og_image
     field: common.image
@@ -28,3 +29,4 @@ fields:
       instructions: "This entry's OG image. Defaults to global site OG image. The recommended size is 1200px x 630px. The image will be focal cropped to this dimension."
       instructions_position: below
       width: 50
+      localizable: true

--- a/resources/fieldsets/seo_sitemap.yaml
+++ b/resources/fieldsets/seo_sitemap.yaml
@@ -24,6 +24,7 @@ fields:
       default: weekly
       listable: hidden
       display: 'Change frequency'
+      localizable: true
   -
     handle: sitemap_priority
     field:
@@ -34,3 +35,4 @@ fields:
       instructions_position: below
       width: 50
       listable: hidden
+      localizable: true


### PR DESCRIPTION
Based on discussion #45.

All fields should be localizable by default, so that websites can override them, if necessary.

This is especially useful, but not limited to, tracking and consent scripts.