### PR TITLE
Add method to accept only one consent type

### DIFF
--- a/resources/views/components/_consent_banner.antlers.html
+++ b/resources/views/components/_consent_banner.antlers.html
@@ -95,6 +95,12 @@
                     this.data.types.forEach((type) => type.value = true)
                     this.saveConsent()
                 },
+                accept(handle) {
+                    this.data.types.filter((type) => {
+                        return type['handle'] === handle
+                    }).forEach((type) => type.value = true)
+                    this.saveConsent()
+                },
                 getConsent() {
                     return this.data.consent
                 },


### PR DESCRIPTION
Follow-up on discussion #50 and preparation for another PR in the [statamic-peak](https://github.com/studio1902/statamic-peak) repo.

This allows to accept a single consent type.