### PR TITLE
Add Umami analytics support

### DIFF
--- a/resources/fieldsets/globals_seo_trackers_analytics.yaml
+++ b/resources/fieldsets/globals_seo_trackers_analytics.yaml
@@ -67,6 +67,43 @@ fields:
       if:
         use_plausible: 'equals true'
   -
+    handle: use_umami
+    field:
+      type: toggle
+      instructions: 'Add Umami tracking code to your head.'
+      listable: false
+      display: Umami
+      localizable: true
+  -
+    handle: umami_website_id
+    field:
+      display: 'Website ID'
+      instructions: 'Only add the website ID.'
+      input_type: text
+      type: text
+      listable: hidden
+      width: 50
+      localizable: true
+      validate:
+        - 'required_if:use_umami,true'
+      if:
+        use_umami: 'equals true'
+  -
+    handle: umami_script_url
+    field:
+      display: 'Script URL'
+      instructions: 'The Umami script URL. Use https://cloud.umami.is/script.js for Umami Cloud.'
+      input_type: text
+      type: text
+      listable: hidden
+      width: 50
+      localizable: true
+      default: 'https://cloud.umami.is/script.js'
+      validate:
+        - 'required_if:use_umami,true'
+      if:
+        use_umami: 'equals true'
+  -
     handle: use_cloudflare_web_analytics
     field:
       type: toggle

--- a/resources/views/snippets/_seo.antlers.html
+++ b/resources/views/snippets/_seo.antlers.html
@@ -234,6 +234,10 @@
         </script>
     {{ /if }}
 
+    {{ if seo:use_umami && seo:umami_website_id && seo:umami_script_url }}
+        <script defer src="{{ seo:umami_script_url }}" data-website-id="{{ seo:umami_website_id }}"></script>
+    {{ /if }}
+
     {{ if seo:use_cloudflare_web_analytics }}
         <script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "{{ seo:cloudflare_web_analytics }}"}'></script>
     {{ /if }}


### PR DESCRIPTION
## Summary

Umami can now be selected as an analytics provider alongside the existing tracker options. The global tracker settings collect a website ID and configurable script URL, so both Umami Cloud and self-hosted installs can render the expected tracking script.

## Test Plan

- Parsed `resources/fieldsets/globals_seo_trackers_analytics.yaml` with Ruby's YAML loader.
- Ran `git diff --check`.
